### PR TITLE
Ruby 1.9.2 compatibility

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -27,10 +27,10 @@ spec = Gem::Specification.new do |s|
   s.test_files        = Dir["spec/**/*"]
 
   require 'bundler'
-  bundle = Bundler::Definition.build("Gemfile", "Gemfile.lock", nil)
+  bundle = Bundler::Definition.from_gemfile("Gemfile")
   bundle.dependencies.
     select { |d| d.groups.include?(:runtime) }.
-    each   { |d| s.add_dependency(d.name, d.requirement.to_s)  }
+    each   { |d| s.add_dependency(d.name, d.version_requirements.to_s)  }
 end
 
 Rake::GemPackageTask.new(spec) do |package|

--- a/Rakefile
+++ b/Rakefile
@@ -27,10 +27,10 @@ spec = Gem::Specification.new do |s|
   s.test_files        = Dir["spec/**/*"]
 
   require 'bundler'
-  bundle = Bundler::Definition.from_gemfile("Gemfile")
+  bundle = Bundler::Definition.build("Gemfile", "Gemfile.lock", nil)
   bundle.dependencies.
     select { |d| d.groups.include?(:runtime) }.
-    each   { |d| s.add_dependency(d.name, d.version_requirements.to_s)  }
+    each   { |d| s.add_dependency(d.name, d.requirement.to_s)  }
 end
 
 Rake::GemPackageTask.new(spec) do |package|

--- a/Rakefile
+++ b/Rakefile
@@ -27,10 +27,10 @@ spec = Gem::Specification.new do |s|
   s.test_files        = Dir["spec/**/*"]
 
   require 'bundler'
-  bundle = Bundler::Definition.from_gemfile("Gemfile")
+  bundle = Bundler::Definition.build("Gemfile", "Gemfile.lock", nil)
   bundle.dependencies.
     select { |d| d.groups.include?(:runtime) }.
-    each   { |d| s.add_dependency(d.name, d.version_requirements.to_s)  }
+    each   { |d| s.add_dependency(d.name, d.requirement.to_s) }
 end
 
 Rake::GemPackageTask.new(spec) do |package|

--- a/lib/rack/client.rb
+++ b/lib/rack/client.rb
@@ -12,7 +12,7 @@ module Rack
     end
 
     def self.new(*a, &block)
-      block ||= lambda {|opt| run Rack::Client::Handler::NetHTTP }
+      block ||= lambda { run Rack::Client::Handler::NetHTTP }
       Rack::Client::Simple.new(Rack::Builder.app(&block), *a)
     end
   end

--- a/lib/rack/client.rb
+++ b/lib/rack/client.rb
@@ -12,7 +12,7 @@ module Rack
     end
 
     def self.new(*a, &block)
-      block ||= lambda { run Rack::Client::Handler::NetHTTP }
+      block ||= lambda {|opt| run Rack::Client::Handler::NetHTTP }
       Rack::Client::Simple.new(Rack::Builder.app(&block), *a)
     end
   end

--- a/lib/rack/client/handler/net_http.rb
+++ b/lib/rack/client/handler/net_http.rb
@@ -49,6 +49,12 @@ module Rack
                   when 'PUT'    then Net::HTTP::Put
                   end
 
+          # Make sure that the query string is forwarded
+          if klass == Net::HTTP::Get && request.env['QUERY_STRING'] && request.env['QUERY_STRING'] != ''
+            path = request.path + "?#{request.env['QUERY_STRING']}" 
+          else
+            path = request.path
+          end
           klass.new(request.path, Headers.from(request.env).to_http)
         end
 

--- a/lib/rack/client/parser/body_collection.rb
+++ b/lib/rack/client/parser/body_collection.rb
@@ -1,7 +1,7 @@
 module Rack
   module Client
     class BodyCollection
-      instance_methods.each { |m| undef_method m unless (m =~ /^__/ || m =~ /^object_id$/ ) }
+      instance_methods.each { |m| undef_method m unless m =~ /^__/ }
 
       def initialize(&load_with_proc)
         raise ArgumentException, 'BodyCollection must be initialized with a block' unless block_given?

--- a/lib/rack/client/parser/body_collection.rb
+++ b/lib/rack/client/parser/body_collection.rb
@@ -1,7 +1,7 @@
 module Rack
   module Client
     class BodyCollection
-      instance_methods.each { |m| undef_method m unless m =~ /^__/ }
+      instance_methods.each { |m| undef_method m unless (m =~ /^__/ || m =~ /^object_id$/ ) }
 
       def initialize(&load_with_proc)
         raise ArgumentException, 'BodyCollection must be initialized with a block' unless block_given?

--- a/spec/auth/basic_spec.rb
+++ b/spec/auth/basic_spec.rb
@@ -1,4 +1,4 @@
-require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
+require File.dirname(__FILE__) + '/../spec_helper'
 
 describe Rack::Client::Auth::Basic do
   context 'Synchronous API' do

--- a/spec/auth/basic_spec.rb
+++ b/spec/auth/basic_spec.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/../spec_helper'
+require File.expand_path(File.join(File.dirname(__FILE__), '..', 'spec_helper'))
 
 describe Rack::Client::Auth::Basic do
   context 'Synchronous API' do


### PR DESCRIPTION
Here is a patch that should make rack-client 1.9.2 compatible and not throw errors as before.
Linecache seems to still not be Ruby 1.9.x compatible but I fixed the small few issues rack-client itself had with 1.9.
- Matt
