### PR TITLE
Sync API support for em-http under Ruby 1.9 (via em-synchrony)

### DIFF
--- a/lib/rack/client/handler/em-http.rb
+++ b/lib/rack/client/handler/em-http.rb
@@ -6,6 +6,11 @@ module Rack
       class EmHttp
         include Rack::Client::DualBand
 
+        class << self
+          extend Forwardable
+          def_delegator :new, :call
+        end
+
         def sync_call(env)
           raise("Synchronous API is not supported for EmHttp Handler") unless block_given?
         end

--- a/lib/rack/client/handler/em-http.rb
+++ b/lib/rack/client/handler/em-http.rb
@@ -12,7 +12,13 @@ module Rack
         end
 
         def sync_call(env)
-          raise("Synchronous API is not supported for EmHttp Handler") unless block_given?
+          if defined?(EventMachine::Synchrony)
+            request = Rack::Request.new(env)
+            resp = connection(request.url).send(request.request_method.downcase, request_options(request))
+            parse(resp).finish
+          else
+            raise("Synchronous API is not supported for EmHttp Handler") unless block_given?
+          end
         end
 
         def async_call(env)


### PR DESCRIPTION
Ran into some issues while playing with rack-client + added sync API support for Ruby 1.9 users.

Ex: https://gist.github.com/802391
