### PR TITLE
1.8.7 vs. 1.9.2 compat fix when seeing if a request body can be `rack.input`

### DIFF
--- a/lib/rack/client/adapter/base.rb
+++ b/lib/rack/client/adapter/base.rb
@@ -45,7 +45,7 @@ module Rack
         env.update 'SCRIPT_NAME'  => ''
         env.update 'QUERY_STRING' => uri.query.to_s
 
-        input  = body.respond_to?(:each) ? body : StringIO.new(body.to_s)
+        input  = ensure_acceptable_input(body)
         errors = StringIO.new
 
         [ input, errors ].each do |io|
@@ -63,6 +63,16 @@ module Rack
         env.update 'HTTPS'  => env["rack.url_scheme"] == "https" ? "on" : "off"
 
         env
+      end
+
+      def ensure_acceptable_input(body)
+        if body.respond_to?(:rewind)
+          body
+        elsif Array === body
+          StringIO.new(body.join)
+        else
+          StringIO.new(body.to_s)
+        end
       end
     end
   end


### PR DESCRIPTION
Use `rewind` as the magic method to determine if a body is ready to be `rack.input`.

Using `each` has 1.8.7 vs. 1.9.2 problems as in 1.8.7 String responds
to `each` but not `rewind` as some things expect.
