### PR TITLE
Add Faraday Adapter

### DIFF
--- a/lib/rack/client/adapter/faraday.rb
+++ b/lib/rack/client/adapter/faraday.rb
@@ -1,0 +1,58 @@
+require 'faraday'
+
+module Faraday
+  class Adapter
+
+    class RackClient < Faraday::Adapter
+      dependency 'rack/client'
+
+      def initialize(faraday_app, rack_client_adapter = :default, *a, &b)
+        super(faraday_app)
+
+        klass = case rack_client_adapter
+                when :default then ::Rack::Client
+                when :simple  then ::Rack::Client::Simple
+                when :base    then ::Rack::Client::Base
+                else rack_client_adapter
+                end
+
+        @rack_client_app = klass.new(*a, &b)
+      end
+
+      def call(faraday_env)
+        rack_env = to_rack_env(faraday_env)
+        timeout  = faraday_env[:request][:timeout] || faraday_env[:request][:open_timeout]
+
+        rack_response = if timeout
+          Timer.timeout(timeout, Faraday::Error::TimeoutError) { @rack_client_app.call(rack_env) }
+        else
+          @rack_client_app.call(rack_env)
+        end
+
+        status, headers, rack_body = rack_response.to_a
+
+        body = ''
+        rack_body.each {|part| body << part }
+
+        rack_body.close if rack_body.respond_to? :close
+
+        save_response(faraday_env, status, body, headers)
+
+        @app.call faraday_env
+      end
+
+      def to_rack_env(faraday_env)
+        body = faraday_env.body
+        body = body.read if body.respond_to? :read
+
+        @rack_client_app.build_env(faraday_env.method.to_s.upcase,
+                                   faraday_env.url.to_s,
+                                   faraday_env.request_headers,
+                                   body)
+      end
+
+    end
+
+    register_middleware nil, :rack_client => RackClient
+  end
+end

--- a/rack-client.gemspec
+++ b/rack-client.gemspec
@@ -18,4 +18,5 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'em-http-request'
   s.add_development_dependency 'typhoeus'
   s.add_development_dependency 'json'
+  s.add_development_dependency 'faraday', '>= 0.9.0.rc1'
 end

--- a/spec/adapter/faraday_spec.rb
+++ b/spec/adapter/faraday_spec.rb
@@ -3,7 +3,7 @@ require 'rack/client/adapter/faraday'
 
 describe Faraday::Adapter::RackClient do
 
-  let(:url) { URI.join(@base_url, '/faraday') }
+  let(:url) { @base_url }
 
   let(:conn) do
     Faraday.new(:url => url) do |faraday|
@@ -12,7 +12,7 @@ describe Faraday::Adapter::RackClient do
 
       faraday.adapter(:rack_client) do |builder|
         builder.use Rack::Lint
-        builder.run Rack::Client::Handler::NetHTTP.new
+        builder.run LiveServer
       end
     end
   end
@@ -39,8 +39,6 @@ describe Faraday::Adapter::RackClient do
     end
 
     it 'with body' do
-      pending "Faraday tests a GET request with a POST body, which rack-client forbids."
-
       response = conn.get('echo') do |req|
         req.body = {'bodyrock' => true}
       end

--- a/spec/adapter/faraday_spec.rb
+++ b/spec/adapter/faraday_spec.rb
@@ -46,5 +46,35 @@ describe Faraday::Adapter::RackClient do
       response.body.should == %(get {"bodyrock"=>"true"})
     end
 
+    it 'sends user agent' do
+      response = conn.get('echo_header', {:name => 'user-agent'}, :user_agent => 'Agent Faraday')
+      response.body.should == 'Agent Faraday'
+    end
+
+  end
+
+  describe 'POST' do
+
+    it 'send url encoded params' do
+      conn.post('echo', :name => 'zack').body.should == %(post {"name"=>"zack"})
+    end
+
+    it 'send url encoded nested params' do
+      response = conn.post('echo', 'name' => {'first' => 'zack'})
+      response.body.should == %(post {"name"=>{"first"=>"zack"}})
+    end
+
+    it 'retrieves the response headers' do
+      conn.post('echo').headers['content-type'].should =~ %r{text/plain}
+    end
+
+    it 'sends files' do
+      response = conn.post('file') do |req|
+        req.body = {'uploaded_file' => Faraday::UploadIO.new(__FILE__, 'text/x-ruby')}
+      end
+
+      response.body.should == 'file faraday_spec.rb text/x-ruby'
+    end
+
   end
 end

--- a/spec/adapter/faraday_spec.rb
+++ b/spec/adapter/faraday_spec.rb
@@ -94,4 +94,12 @@ describe Faraday::Adapter::RackClient do
     end
 
   end
+
+  describe 'PATCH' do
+
+    it 'send url encoded params' do
+      conn.patch('echo', :name => 'zack').body.should == %(patch {"name"=>"zack"})
+    end
+
+  end
 end

--- a/spec/adapter/faraday_spec.rb
+++ b/spec/adapter/faraday_spec.rb
@@ -120,4 +120,16 @@ describe Faraday::Adapter::RackClient do
     end
 
   end
+
+  describe 'DELETE' do
+
+    it 'retrieves the response headers' do
+      conn.delete('echo').headers['content-type'].should =~ %r{text/plain}
+    end
+
+    it 'retrieves the body' do
+      conn.delete('echo').body.should == %(delete)
+    end
+
+  end
 end

--- a/spec/adapter/faraday_spec.rb
+++ b/spec/adapter/faraday_spec.rb
@@ -1,0 +1,24 @@
+require 'spec_helper'
+require 'rack/client/adapter/faraday'
+
+describe Faraday::Adapter::RackClient do
+
+  let(:url) { URI.join(@base_url, '/faraday') }
+
+  let(:conn) do
+    Faraday.new(:url => url) do |faraday|
+      faraday.adapter(:rack_client) do |builder|
+        builder.use Rack::Lint
+        builder.run Rack::Client::Handler::NetHTTP.new
+      end
+    end
+  end
+
+  describe 'GET' do
+
+    it 'retrieves the response body' do
+      conn.get('echo').body.should == 'get'
+    end
+
+  end
+end

--- a/spec/adapter/faraday_spec.rb
+++ b/spec/adapter/faraday_spec.rb
@@ -77,4 +77,21 @@ describe Faraday::Adapter::RackClient do
     end
 
   end
+
+  describe 'PUT' do
+
+    it 'send url encoded params' do
+      conn.put('echo', :name => 'zack').body.should == %(put {"name"=>"zack"})
+    end
+
+    it 'send url encoded nested params' do
+      response = conn.put('echo', 'name' => {'first' => 'zack'})
+      response.body.should == %(put {"name"=>{"first"=>"zack"}})
+    end
+
+    it 'retrieves the response headers' do
+      conn.put('echo').headers['content-type'].should =~ %r{text/plain}
+    end
+
+  end
 end

--- a/spec/adapter/faraday_spec.rb
+++ b/spec/adapter/faraday_spec.rb
@@ -108,4 +108,16 @@ describe Faraday::Adapter::RackClient do
     specify { conn.run_request(:options, 'echo', nil, {}).body.should == 'options' }
 
   end
+
+  describe 'HEAD' do
+
+    it 'retrieves no response body' do
+      conn.head('echo').body.should == ''
+    end
+
+    it 'retrieves the response headers' do
+      conn.head('echo').headers['content-type'].should =~ %r{text/plain}
+    end
+
+  end
 end

--- a/spec/adapter/faraday_spec.rb
+++ b/spec/adapter/faraday_spec.rb
@@ -102,4 +102,10 @@ describe Faraday::Adapter::RackClient do
     end
 
   end
+
+  describe 'OPTIONS' do
+
+    specify { conn.run_request(:options, 'echo', nil, {}).body.should == 'options' }
+
+  end
 end

--- a/spec/spec_apps/faraday.ru
+++ b/spec/spec_apps/faraday.ru
@@ -1,0 +1,61 @@
+require 'sinatra/base'
+
+class LiveServer < Sinatra::Base
+  set :environment, :test
+  disable :logging
+  disable :protection
+
+  [:get, :post, :put, :patch, :delete, :options].each do |method|
+    send(method, '/echo') do
+      kind = request.request_method.downcase
+      out = kind.dup
+      out << ' ?' << request.GET.inspect if request.GET.any?
+      out << ' ' << request.POST.inspect if request.POST.any?
+
+      content_type 'text/plain'
+      return out
+    end
+  end
+
+  get '/echo_header' do
+    header = "HTTP_#{params[:name].tr('-', '_').upcase}"
+    request.env.fetch(header) { 'NONE' }
+  end
+
+  post '/file' do
+    if params[:uploaded_file].respond_to? :each_key
+      "file %s %s" % [
+        params[:uploaded_file][:filename],
+        params[:uploaded_file][:type]]
+    else
+      status 400
+    end
+  end
+
+  get '/multi' do
+    [200, { 'Set-Cookie' => 'one, two' }, '']
+  end
+
+  get '/who-am-i' do
+    request.env['REMOTE_ADDR']
+  end
+
+  get '/slow' do
+    sleep 10
+    [200, {}, 'ok']
+  end
+
+  get '/204' do
+    status 204 # no content
+  end
+
+  get '/ssl' do
+    request.secure?.to_s
+  end
+
+  error do |e|
+    "#{e.class}\n#{e.to_s}\n#{e.backtrace.join("\n")}"
+  end
+end
+
+run LiveServer


### PR DESCRIPTION
An implementation of the rack-client adapter for faraday described here: lostisland/faraday#244

For applications or libraries that use faraday and allow for a configurable adapter, this adds support for injecting a rack-client stack into the faraday client configuration. For example, if I wanted to test my rails app directly from my client app:

``` ruby
MyClient.new do |faraday_builder|
  faraday_builder.adapter :rack_client do |rack_builder|
    rack_builder.use Rack::Lint
    rack_builder.run MyApp.new
  end
end
```
