### PR TITLE
Close out body after reading if available

### DIFF
--- a/lib/rack/client/core/response.rb
+++ b/lib/rack/client/core/response.rb
@@ -34,6 +34,8 @@ module Rack
           end
         end
 
+        @body.close if @body.respond_to?(:close)
+
         if @stream
           @stream.call(lambda do |chunk|
             unless chunk.empty?

--- a/spec/core/response_spec.rb
+++ b/spec/core/response_spec.rb
@@ -74,5 +74,15 @@ describe Rack::Client::Response do
 
       response.body.should == check
     end
+
+    it 'will close body after loading' do
+      body = Rack::BodyProxy.new(%w[ Should get closed ]) { }
+
+      response = Rack::Client::Response.new(200, {}, body)
+
+      response.body
+
+      body.should be_closed
+    end
   end
 end


### PR DESCRIPTION
In more recent versions of Rack, if the body provides a `#close` method, that
is expected to be called after iteration over the contents of the body. (See
https://github.com/rack/rack/blob/ed9050876dfa2418613db05fb52015dc97cb78fb/SPEC#L250-L252
for the relevant section of the spec).

We ran into this when updating some tests that use the
`ey_services_fake` gem which internally relies on `Rack::Client`. This
was ending up making a call that went through the `Rack::Lock`
middleware, and then would hang on any second request because the
`Rack::BodyProxy` that was holding a lock never properly closed out once
`Rack::Client::Response` replaced the body.
